### PR TITLE
feat: improve multi-platform build compatibility

### DIFF
--- a/build.py
+++ b/build.py
@@ -6,15 +6,21 @@ from pathlib import Path
 
 from setuptools import Extension
 from setuptools.command.build_ext import build_ext
-
+import platform
 # https://github.com/pybind/cmake_example/blob/master/setup.py
 
-# Convert distutils Windows platform specifiers to CMake -A arguments
+# Convert distutils platform specifiers to CMake -A arguments
 PLAT_TO_CMAKE = {
     "win32": "Win32",
     "win-amd64": "x64",
     "win-arm32": "ARM",
     "win-arm64": "ARM64",
+    "darwin": "Darwin",  # macOS
+    "linux": "Linux",  # Linux
+    "linux-x86_64": "Linux-x86_64",
+    "linux-aarch64": "Linux-aarch64",
+    "darwin-x86_64": "Darwin-x86_64",
+    "darwin-arm64": "Darwin-arm64",
 }
 
 
@@ -59,11 +65,28 @@ class CMakeBuild(build_ext):
 
         if sys.platform.startswith("win32"):
             build_args += ["--config", cfg]
+        elif sys.platform.startswith("darwin") or sys.platform.startswith("linux"):
+            # Use Unix Makefiles for macOS and Linux
+            cmake_args += ["-G", "Unix Makefiles"]
         if sys.platform.startswith("darwin"):
             # Cross-compile support for macOS - respect ARCHFLAGS if set
             archs = re.findall(r"-arch (\S+)", os.environ.get("ARCHFLAGS", ""))
             if archs:
                 cmake_args += ["-DCMAKE_OSX_ARCHITECTURES={}".format(";".join(archs))]
+            else:
+                # Auto-detect macOS architecture
+                machine = platform.machine()
+                if machine == "arm64":
+                    cmake_args += ["-DCMAKE_OSX_ARCHITECTURES=arm64"]
+                elif machine == "x86_64":
+                    cmake_args += ["-DCMAKE_OSX_ARCHITECTURES=x86_64"]
+        elif sys.platform.startswith("linux"):
+            # Linux architecture detection
+            machine = platform.machine()
+            if machine == "aarch64":
+                cmake_args += ["-DCMAKE_SYSTEM_PROCESSOR=aarch64"]
+            elif machine == "x86_64":
+                cmake_args += ["-DCMAKE_SYSTEM_PROCESSOR=x86_64"]
 
         # Set CMAKE_BUILD_PARALLEL_LEVEL to control the parallel build level
         # across all generators.
@@ -97,7 +120,7 @@ class CMakeBuild(build_ext):
 
 def build(setup_kwargs):
     ext_modules = [
-        CMakeExtension("graph_id_cpp", sourcedir="."),
+        CMakeExtension("graph_id_cpp"),
     ]
     setup_kwargs.update(
         {


### PR DESCRIPTION
- Add macOS and Linux platform identifiers
- Implement automatic architecture detection
- Use Unix Makefiles for macOS/Linux
- Simplify CMakeExtension configuration
- Fix issue where `graph-id-core` fails to work when running `pants package` and `pants test` on Debian 12 (Bookworm)