### PR TITLE
Upgrade cibuildwheel to version 3.0.0

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -17,7 +17,7 @@ jobs:
           submodules: recursive
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.23.4
+        uses: pypa/cibuildwheel@v3.0.0
         env:
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.11"
           CIBW_SKIP: "pp* *musllinux*"  # Skip musl Linux builds if spglib doesn't work well. pybind11 doesn't support PyPy. Therefore skip PyPy.


### PR DESCRIPTION
Updated cibuildwheel version to v3.0.0 for building wheels.