### PR TITLE
Fix Renovate config and ruff/black docstring conflict

### DIFF
--- a/build.py
+++ b/build.py
@@ -29,7 +29,6 @@ PLAT_TO_CMAKE = {
 # The name must be the _single_ output extension from the CMake build.
 # If you need multiple extensions, see scikit-build.
 class CMakeExtension(Extension):
-
     """A CMake extension for building C++ code with setuptools."""
 
     def __init__(self, name: str, sourcedir: str = "") -> None:
@@ -48,7 +47,6 @@ class CMakeExtension(Extension):
 
 
 class CMakeBuild(build_ext):
-
     """Custom build_ext command that uses CMake to build C++ extensions."""
 
     def build_extension(self, ext: CMakeExtension) -> None:  # noqa: C901,PLR0912

--- a/docs/_stubs/graph_id_cpp/__init__.py
+++ b/docs/_stubs/graph_id_cpp/__init__.py
@@ -3,7 +3,6 @@
 
 
 class GraphIDGenerator:
-
     """C++ implementation of Graph ID generator."""
 
     def __init__(self, **kwargs):
@@ -18,17 +17,14 @@ class GraphIDGenerator:
 
 
 class MinimumDistanceNN:
-
     """C++ implementation of MinimumDistanceNN."""
 
 
 class CrystalNN:
-
     """C++ implementation of CrystalNN."""
 
 
 class CutOffDictNN:
-
     """C++ implementation of CutOffDictNN."""
 
     def __init__(self, cutoff_dict):
@@ -36,7 +32,6 @@ class CutOffDictNN:
 
 
 class StructureGraph:
-
     """C++ implementation of StructureGraph."""
 
     @staticmethod

--- a/examples/machine_learning/train.py
+++ b/examples/machine_learning/train.py
@@ -57,7 +57,6 @@ feat_names = featurizer.feature_labels()
 
 
 class CifToStructure(ConversionFeaturizer):  # type: ignore
-
     """Convert CIF strings to pymatgen Structure objects."""
 
     def __init__(self, target_col_id="cif", overwrite_data=False) -> None:

--- a/graph_id/analysis/compositional_sequence.py
+++ b/graph_id/analysis/compositional_sequence.py
@@ -16,7 +16,6 @@ def blake(s):
 
 
 class CompositionalSequence:
-
     """Compute the compositional sequence for a site in a structure graph.
 
     A compositional sequence is a fingerprint of the local chemical environment

--- a/graph_id/analysis/graphs.py
+++ b/graph_id/analysis/graphs.py
@@ -37,7 +37,6 @@ def standardize_loop(lst):
 
 
 class SiteOnlySpeciesString:
-
     """Lightweight wrapper containing only the species string of a site.
 
     Used to reduce memory when only element information is needed.
@@ -55,7 +54,6 @@ class SiteOnlySpeciesString:
 
 
 class ConnectedSiteLight:
-
     """Lightweight representation of a connected site.
 
     A memory-efficient alternative to pymatgen's ConnectedSite that stores
@@ -106,7 +104,6 @@ class ConnectedSiteLight:
 
 
 class StructureGraph(PmgStructureGraph):  # type: ignore
-
     """Extended StructureGraph with methods for Graph ID computation.
 
     This class extends pymatgen's StructureGraph with additional functionality

--- a/graph_id/analysis/local_env.py
+++ b/graph_id/analysis/local_env.py
@@ -47,7 +47,6 @@ def _get_original_site(structure, site):
 
 
 class DistanceClusteringNN(NearNeighbors):
-
     """Neighbor detection using DBSCAN clustering on interatomic distances.
 
     This class identifies neighbors by clustering the distribution of

--- a/graph_id/app/maker.py
+++ b/graph_id/app/maker.py
@@ -14,7 +14,6 @@ from graph_id.core.graph_id import GraphIDGenerator as PyGraphIDGenerator
 
 
 class GraphIDMaker:
-
     """A simple, high-level interface for generating Graph IDs.
 
     GraphIDMaker provides an easy-to-use API for generating unique identifiers

--- a/graph_id/core/distance_clustering_graph_id.py
+++ b/graph_id/core/distance_clustering_graph_id.py
@@ -13,7 +13,6 @@ from graph_id.core.graph_id import GraphIDGenerator
 
 
 class DistanceClusteringGraphID(GraphIDGenerator):
-
     """Graph ID generator using DBSCAN distance clustering for neighbor detection.
 
     This variant uses DBSCAN clustering on interatomic distances to identify

--- a/graph_id/core/graph_id.py
+++ b/graph_id/core/graph_id.py
@@ -18,7 +18,6 @@ from graph_id.analysis.graphs import StructureGraph
 
 
 class GraphIDGenerator:
-
     """Core Python implementation of Graph ID generation.
 
     GraphIDGenerator converts atomic structures into unique, deterministic identifiers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ lint.ignore = [
   "ANN201", #  Missing return type annotation for public function
   "SLF001", # Private member accessed
   "ERA001", # commentouted code is allowed
-  "D211",
+  "D203",
   "D213",
   "PGH003",
   "ANN202",


### PR DESCRIPTION
## Summary
- Restores the `matchUpdateTypes` selector on the `automerge` packageRule in `.github/renovate.json`, which Renovate rejected as invalid (`packageRules[0]: Each packageRule must contain at least one match* or exclude* selector`). Fixes #143.
- Fixes a ruff/black conflict that was causing pre-commit.ci to fail on every run: `pyproject.toml` ignored `D211` instead of its mutually-exclusive opposite `D203`, so ruff kept re-inserting the blank line before class docstrings that black immediately strips back out. Swapped the ignore to `D203` and reformatted the 9 affected files to match.

## Test plan
- [x] `black --check .` passes
- [x] `ruff check .` passes
- [x] `pyproject.toml` parses as valid TOML
- [x] pre-commit hooks (black, ruff, codespell, mypy, etc.) all pass locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new example for converting CIF text into structure objects in the machine-learning workflow.
  - Expanded graph analysis capabilities for building and labeling structure graphs, including improved support for sequence and loop-based graph descriptors.

- **Documentation**
  - Cleaned up and repositioned multiple class docstrings for better readability and generated API documentation.

- **Chores**
  - Adjusted lint configuration and minor formatting around class definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->