### PR TITLE
Add get_merged_id to C++

### DIFF
--- a/cpp/graph_id.cpp
+++ b/cpp/graph_id.cpp
@@ -120,6 +120,67 @@ std::vector<std::string> GraphIDGenerator::get_component_ids(const Structure &st
     return std::vector<std::string>(structure.count);
 }
 
+py::object GraphIDGenerator::_molecule_to_structure(const py::object &mol) const {
+    constexpr double vacuum = 10.0;
+
+    py::object coords = mol.attr("cart_coords");
+    py::object species = mol.attr("species");
+
+    py::object min_c = coords.attr("min")(py::arg("axis") = 0);
+    py::object max_c = coords.attr("max")(py::arg("axis") = 0);
+    py::object lengths = max_c - min_c + py::float_(2 * vacuum);
+
+    auto length_at = [](const py::object &arr, int i) {
+        return arr.attr("__getitem__")(i).cast<double>();
+    };
+
+    py::object pymatgen_core = py::module_::import("pymatgen.core");
+    py::object lattice = pymatgen_core.attr("Lattice").attr("from_parameters")(
+            length_at(lengths, 0), length_at(lengths, 1), length_at(lengths, 2), 90.0, 90.0, 90.0);
+
+    py::object shifted_coords = coords - min_c + py::float_(vacuum);
+
+    return pymatgen_core.attr("Structure")(
+            lattice, species, shifted_coords, py::arg("coords_are_cartesian") = true);
+}
+
+std::string GraphIDGenerator::get_merged_id(const py::list &materials_list) const {
+    py::object pymatgen_core = py::module_::import("pymatgen.core");
+    py::object structure_cls = pymatgen_core.attr("Structure");
+    py::object molecule_cls = pymatgen_core.attr("Molecule");
+    py::object atoms_cls = py::module_::import("ase").attr("Atoms");
+    py::object ase_adaptor_cls = py::module_::import("pymatgen.io.ase").attr("AseAtomsAdaptor");
+
+    std::vector<std::string> array_list;
+
+    for (const auto &material: materials_list) {
+        py::object structure_py;
+
+        if (py::isinstance(material, structure_cls)) {
+            structure_py = py::reinterpret_borrow<py::object>(material);
+        } else if (py::isinstance(material, molecule_cls)) {
+            structure_py = _molecule_to_structure(py::reinterpret_borrow<py::object>(material));
+        } else if (py::isinstance(material, atoms_cls)) {
+            structure_py = ase_adaptor_cls.attr("get_structure")(material);
+        } else {
+            std::string type_name = py::str(material.attr("__class__").attr("__name__")).cast<std::string>();
+            throw py::type_error(
+                    "Item of materials_list must be pymatgen.core.Structure, "
+                    "pymatgen.core.Molecule, or ase.Atoms, got " + type_name);
+        }
+
+        auto s = structure_py.cast<PymatgenStructure>();
+        auto s_ptr = std::make_shared<const Structure>(s);
+        const auto sg = prepare_structure_graph(s_ptr);
+
+        for (const auto &cs_list: sg.cc_cs) {
+            array_list.push_back(_join_cs_list(cs_list));
+        }
+    }
+
+    return _component_strings_to_whole_id(array_list);
+}
+
 bool GraphIDGenerator::are_same(const Structure &structure1, const Structure &structure2) const {
     return this->get_id(structure1) == this->get_id(structure2);
 }
@@ -342,6 +403,7 @@ void init_graph_id(pybind11::module &m) {
                 auto s = structure.cast<PymatgenStructure>();
                 return gig.get_component_ids(Structure(s));
             })
+            .def("get_merged_id", &GraphIDGenerator::get_merged_id)
             .def("are_same", [](const GraphIDGenerator &gig, py::object &structure1, py::object &structure2) {
                 auto s1 = structure1.cast<PymatgenStructure>();
                 auto s2 = structure2.cast<PymatgenStructure>();

--- a/cpp/graph_id.h
+++ b/cpp/graph_id.h
@@ -48,6 +48,8 @@ public:
 
     std::vector<std::string> get_component_ids(const Structure &structure) const;
 
+    std::string get_merged_id(const py::list &materials_list) const;
+
     std::string elaborate_comp_dim(const StructureGraph &sg, const std::string &gid) const;
 
     bool are_same(const Structure &structure1, const Structure &structure2) const;
@@ -58,6 +60,8 @@ public:
     StructureGraph prepare_structure_graph(std::shared_ptr<const Structure> &structure) const;
 
 private:
+    py::object _molecule_to_structure(const py::object &mol) const;
+
     StructureGraph prepare_structure_graph_from_existing(std::shared_ptr<const Structure> &structure, const StructureGraph &sg) const;
     StructureGraph prepare_minimum_distance_structure_graph(std::shared_ptr<const Structure> &structure) const;
     StructureGraph prepare_disctance_clustering_structure_graph(int n, std::shared_ptr<const Structure> &structure, std::shared_ptr<StructureGraph> &_sg, int rank_k, double cutoff) const;

--- a/tests/cpp/test_graph_id.py
+++ b/tests/cpp/test_graph_id.py
@@ -5,15 +5,17 @@ import glob
 import os
 import unittest
 
+from ase.io import read
 from pymatgen.analysis.graphs import StructureGraph
 from pymatgen.analysis.local_env import CrystalNN, CutOffDictNN, MinimumDistanceNN
-from pymatgen.core import Structure
+from pymatgen.core import Molecule, Structure
 
 import graph_id
 
 from .imports import graph_id_cpp
 
 test_file_dir = os.path.normpath(os.path.join(os.path.dirname(__file__), "../../graph_id/tests/test_files"))
+PY_TEST_FILES = os.path.normpath(os.path.join(os.path.dirname(__file__), "../py/test_files"))
 
 
 def small_test_structure(max_sites=30):
@@ -78,6 +80,37 @@ class TestGraphIDGenerator(unittest.TestCase):
         assert gid_gen_cpp.get_id_with_structure_graph(sg_py_mdn) == gid_gen_cpp.get_id_with_structure_graph(
             sg_cpp_mdn,
         )
+
+    def test_merged_id(self):
+        a = graph_id.GraphIDGenerator(prepend_composition=False, prepend_dimensionality=False)
+        b = graph_id_cpp.GraphIDGenerator()
+
+        graphite_structure = Structure.from_file(os.path.join(PY_TEST_FILES, "graphite.cif"))
+        h2_atoms = read(os.path.join(PY_TEST_FILES, "h.xyz"))
+        h2_atoms.set_cell([20, 20, 20])
+        h2_molecule = Molecule.from_file(os.path.join(PY_TEST_FILES, "h.xyz"))
+        graphite_h = Structure.from_file(os.path.join(PY_TEST_FILES, "graphite_h.cif"))
+
+        expected = a.get_merged_id([graphite_structure, h2_atoms])
+
+        self.assertEqual(b.get_merged_id([graphite_structure, h2_atoms]), expected)
+        self.assertEqual(b.get_merged_id([graphite_structure, h2_molecule]), expected)
+        self.assertEqual(b.get_merged_id([graphite_structure, h2_atoms]), b.get_id(graphite_h))
+
+    def test_merged_id_type_error(self):
+        b = graph_id_cpp.GraphIDGenerator()
+        graphite_structure = Structure.from_file(os.path.join(PY_TEST_FILES, "graphite.cif"))
+
+        with self.assertRaises(TypeError):
+            b.get_merged_id([graphite_structure, "not a structure"])
+
+    def test_merged_id_digest_size(self):
+        b = graph_id_cpp.GraphIDGenerator(digest_size=4)
+        graphite_structure = Structure.from_file(os.path.join(PY_TEST_FILES, "graphite.cif"))
+
+        merged_id = b.get_merged_id([graphite_structure])
+        self.assertEqual(len(merged_id), 8)
+        self.assertEqual(merged_id, b.get_id(graphite_structure))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add get_merged_id to C++

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for generating a single merged graph ID from lists containing structures, molecules, and atomic configurations.
  - Added automatic molecule conversion for consistent graph ID generation.
  - Added configurable digest sizes for merged IDs.

- **Bug Fixes**
  - Unsupported input types now produce a clear type error.

- **Tests**
  - Added coverage for merged IDs, mixed material types, invalid inputs, and custom digest sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->